### PR TITLE
add pch everywhere lty,lwd found so pch gets passed with plot.xts

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -211,6 +211,7 @@ plot.xts <- function(x,
                      lty=1,
                      lwd=2,
                      lend=1,
+                     pch=0,
                      main=deparse(substitute(x)),
                      cex=0.6, 
                      cex.axis=0.9,
@@ -244,6 +245,8 @@ plot.xts <- function(x,
     if(length(col) == 1) col <- rep(col, NCOL(x))
     if(length(lty) == 1) lty <- rep(lty, NCOL(x))
     if(length(lwd) == 1) lwd <- rep(lwd, NCOL(x))
+    
+    if(length(pch) == 1) pch <- rep(pch, NCOL(x))
     
     
     if(!is.null(panels) && nchar(panels) > 0){
@@ -293,6 +296,7 @@ plot.xts <- function(x,
                     type=type,
                     lty=lty[tmp],
                     lwd=lwd[tmp],
+                    pch=pch[tmp],
                     lend=lend,
                     main=main,
                     cex=cex, 
@@ -413,6 +417,9 @@ plot.xts <- function(x,
   if(length(lwd) == 1) lwd <- rep(lwd, NCOL(x))
   cs$Env$lty <- lty
   cs$Env$lwd <- lwd
+  
+  if(length(pch) == 1) pch <- rep(pch, NCOL(x))
+  cs$Env$pch <- pch
   
   cs$Env$lend <- lend
   cs$Env$legend.loc <- legend.loc
@@ -609,6 +616,7 @@ plot.xts <- function(x,
                                   type=type, 
                                   lty=lty,
                                   lwd=lwd,
+                                  pch=pch,
                                   lend=lend,
                                   col=theme$col, 
                                   up.col=theme$up.col, 
@@ -643,6 +651,8 @@ plot.xts <- function(x,
         lenv$lwd <- cs$Env$lwd[i]
         lenv$col <- cs$Env$theme$col[i]
         
+        lenv$pch <- cs$Env$pch[i]
+        
         # Add a small frame
         cs$add_frame(ylim=c(0,1),asp=0.25)
         cs$next_frame()
@@ -661,6 +671,7 @@ plot.xts <- function(x,
                                       type=type, 
                                       lty=lty,
                                       lwd=lwd,
+                                      pch=pch,
                                       lend=lend,
                                       col=col, 
                                       up.col=theme$up.col, 
@@ -721,6 +732,7 @@ plot.xts <- function(x,
                                   type=type, 
                                   lty=lty,
                                   lwd=lwd,
+                                  pch=pch,
                                   lend=lend,
                                   col=theme$col,
                                   up.col=theme$up.col, 


### PR DESCRIPTION
In response to #80, I just went ahead and added the `pch` argument everywhere I found `lwd`,`lty`, so that `pch` will work with the generic `plot.xts`.

I could easily be missing something, but I think what happened is `pch` did not get added when `lines` and `points` got merged.

Now when I do the following, I get the result that I would expect.

```r
plot(sample_matrix.xts[,"Close"],type="p",pch=3,col="gray")
```

![image](https://cloud.githubusercontent.com/assets/837910/7302366/8ca79364-e9ae-11e4-9d75-4a53e4fccc9e.png)
