### PR TITLE
Fix issue where periodicity > 1 but last index = NA

### DIFF
--- a/R/periodicity.R
+++ b/R/periodicity.R
@@ -35,7 +35,7 @@ periodicity <- function(x, ...) {
   if( timeBased(x) || !is.xts(x) )
     x <- try.xts(x, error='\'x\' needs to be timeBased or xtsible')
 
-  p <- median(diff( .index(x) ))
+  p <- median(diff( .index(x) ),na.rm=TRUE)
 
   if( is.na(p) ) stop("can not calculate periodicity of 1 observation")
 


### PR DESCRIPTION
Time series generated by period.apply can have a final index obs of NA which makes this throw an error.  By adding this the error is avoided.