### PR TITLE
Prevent writing out of bounds when final column is entirely NA

### DIFF
--- a/inst/unitTests/runit.na.locf.R
+++ b/inst/unitTests/runit.na.locf.R
@@ -202,3 +202,17 @@ test.nalocf_first_column_all_NA <- function() {
     checkEquals(x, as.xts(z), check.attributes = TRUE)
   }
 }
+
+test.nalocf_last_column_all_NA <- function() {
+  nacol <- NCOL(XDAT2)
+  for (m in MODES) {
+    xdat <- XDAT2
+    xdat[,nacol] <- xdat[,nacol] * NA
+    storage.mode(xdat) <- m
+    zdat <- as.zoo(xdat)
+
+    x <- na.locf(xdat)
+    z <- na.locf(zdat)
+    checkEquals(x, as.xts(z), check.attributes = TRUE)
+  }
+}

--- a/src/na.c
+++ b/src/na.c
@@ -63,7 +63,7 @@ static int firstNonNACol (SEXP x, int col)
       }
       break;
     case STRSXP:
-      for(i=0; i<nr; i++) {
+      for(i=0+col*nr; i<(nr+col*nr); i++) {
         if(STRING_ELT(x, i)!=NA_STRING) {
           break;
         }

--- a/src/na.c
+++ b/src/na.c
@@ -168,6 +168,8 @@ SEXP na_locf (SEXP x, SEXP fromLast, SEXP _maxgap, SEXP _limit)
         for(j=0; j < nc; j++) {
           /* copy leading NAs */
           _first = firstNonNACol(x, j);
+          if (_first == nr + j*nr)
+            _first--;
           for(i=0+j*nr; i < (_first+1); i++) {
             int_result[i] = int_x[i];
           }
@@ -208,6 +210,8 @@ SEXP na_locf (SEXP x, SEXP fromLast, SEXP _maxgap, SEXP _limit)
         for(j=0; j < nc; j++) {
           /* copy leading NAs */
           _first = firstNonNACol(x, j);
+          if (_first == nr + j*nr)
+            _first--;
           for(i=0+j*nr; i < (_first+1); i++) {
             int_result[i] = int_x[i];
           }
@@ -269,6 +273,8 @@ SEXP na_locf (SEXP x, SEXP fromLast, SEXP _maxgap, SEXP _limit)
         for(j=0; j < nc; j++) {
           /* copy leading NAs */
           _first = firstNonNACol(x, j);
+          if (_first == nr + j*nr)
+            _first--;
           for(i=0+j*nr; i < (_first+1); i++) {
             real_result[i] = real_x[i];
           }
@@ -327,6 +333,8 @@ SEXP na_locf (SEXP x, SEXP fromLast, SEXP _maxgap, SEXP _limit)
         for(j=0; j < nc; j++) {
           /* copy leading NAs */
           _first = firstNonNACol(x, j);
+          if (_first == nr + j*nr)
+            _first--;
           for(i=0+j*nr; i < (_first+1); i++) {
             SET_STRING_ELT(result, i, STRING_ELT(x, i));
           }


### PR DESCRIPTION
If a column is entirely NA, then firstNonNACol will return the index
of the first entry of the next column.  In the case where the final
column is entirely NA then this will result in writing off the end of
the allocated result.

Fix by subtracting one from the index in this case.

Hopefully fixes #234