### PR TITLE
Fix multi-column filling when first column all NA

### DIFF
--- a/inst/unitTests/runit.na.locf.R
+++ b/inst/unitTests/runit.na.locf.R
@@ -188,3 +188,17 @@ test.nalocf_by_column_1NA_fromLast <- function() {
     checkEquals(x, as.xts(z), check.attributes = TRUE)
   }
 }
+
+test.nalocf_first_column_all_NA <- function() {
+  nacol <- 1L
+  for (m in MODES) {
+    xdat <- XDAT2
+    xdat[,nacol] <- xdat[,nacol] * NA
+    storage.mode(xdat) <- m
+    zdat <- as.zoo(xdat)
+
+    x <- na.locf(xdat)
+    z <- na.locf(zdat)
+    checkEquals(x, as.xts(z), check.attributes = TRUE)
+  }
+}

--- a/src/na.c
+++ b/src/na.c
@@ -158,9 +158,6 @@ SEXP na_locf (SEXP x, SEXP fromLast, SEXP _maxgap, SEXP _limit)
   limit  = asReal(_limit);
   gap = 0;
 
-  if(firstNonNA(x) == nr)
-    return(x);
-
   PROTECT(result = allocMatrix(TYPEOF(x), nr, nc)); P++;
 
   switch(TYPEOF(x)) {


### PR DESCRIPTION
The firstNonNA check only checks the first column for a 2-dimensional
SEXP.  Therefore if the first column is NA, the function returns
without examining any other columns.

Fix by removing this check.

Fixes #233