### PR TITLE
Restore behaviour from 0.10-2 to .xts()

### DIFF
--- a/R/xts.R
+++ b/R/xts.R
@@ -138,6 +138,9 @@ function(x=NULL, index, tclass=c("POSIXct","POSIXt"),
     .indexFORMAT <- eval(dots.names$.indexFORMAT,parent.frame())
   else
     .indexFORMAT <- NULL
+
+  ## restore behaviour from v0.10-2
+  tclass <- .indexCLASS
   xx <- .Call("add_xtsCoreAttributes", x, index, .indexCLASS, tzone, tclass,
               c('xts','zoo'), .indexFORMAT, PACKAGE='xts')
   # remove .indexFORMAT and .indexTZ that come through Ops.xts

--- a/inst/unitTests/runit.xts.R
+++ b/inst/unitTests/runit.xts.R
@@ -50,3 +50,48 @@ test..xts_dimnames_in_dots <- function() {
   y <- xts(1:5, index(x), dimnames = list(NULL, "x"))
   checkEquals(x, y)
 }
+
+checkXtsClass <- function(xts, class) {
+  checkEquals(tclass(xts), class)
+  checkEquals(indexClass(xts), class)
+  checkEquals(attr(attr(xts, "index"), "tclass"), class)
+}
+
+### Check that .indexCLASS takes precedence over tclass when both specified
+test..xts_class <- function() {
+  checkXtsClass(.xts(1, 1), c("POSIXct", "POSIXt"))
+  checkXtsClass(.xts(1, 1, tclass="timeDate"), "timeDate")
+  checkXtsClass(.xts(1, 1, .indexCLASS="Date"), "Date")
+  checkXtsClass(.xts(1, 1, tclass="timeDate", .indexCLASS="Date"), "Date")
+
+  ## also check that tclass is ignored if specified as part of index
+  checkXtsClass(.xts(1, structure(1, tzone="",tclass="yearmon")), c("POSIXct", "POSIXt"))
+  checkXtsClass(.xts(1, structure(1, tzone="",tclass="yearmon"), tclass="timeDate"), "timeDate")
+  checkXtsClass(.xts(1, structure(1, tzone="",tclass="yearmon"), .indexCLASS="Date"), "Date")
+  checkXtsClass(.xts(1, structure(1, tzone="",tclass="yearmon"), tclass="timeDate", .indexCLASS="Date"), "Date")
+}
+
+checkXtsTz <- function(xts, tzone) {
+  checkEquals(tzone(xts), tzone)
+  checkEquals(indexTZ(xts), tzone)
+  checkEquals(attr(attr(xts, "index"), "tzone"), tzone)
+}
+
+.setUp <- function() {
+  Sys.setenv(TZ="UTC")
+}
+
+### Check that tzone is honoured and .indexTZ ignored
+test..xts_tzone <- function() {
+  checkXtsTz(.xts(1, 1), "UTC")
+  checkXtsTz(.xts(1, 1, tzone="Europe/London"), "Europe/London")
+  ## this case passes in 0.10-2 but looks wrong
+  checkXtsTz(.xts(1, 1, .indexTZ="America/New_York"), "UTC")
+  checkXtsTz(.xts(1, 1, tzone="Europe/London", .indexTZ="America/New_York"), "Europe/London")
+
+  ## Cases where tzone is specified in the index
+  checkXtsTz(.xts(1, structure(1, tzone="Asia/Tokyo",tclass="yearmon")), "Asia/Tokyo")
+  checkXtsTz(.xts(1, structure(1, tzone="Asia/Tokyo",tclass="yearmon"), tzone="Europe/London"), "Europe/London")
+  checkXtsTz(.xts(1, structure(1, tzone="Asia/Tokyo",tclass="yearmon"), .indexTZ="America/New_York"), "Asia/Tokyo")
+  checkXtsTz(.xts(1, structure(1, tzone="Asia/Tokyo",tclass="yearmon"), tzone="Europe/London", .indexTZ="America/New_York"), "Europe/London")
+}


### PR DESCRIPTION
Add unit tests to document the behaviour in 0.10-2 and fix the failures introduced in 0.11.  Fixes #249.