### PR TITLE
Issue #252 fix can't subset

### DIFF
--- a/R/xts.methods.R
+++ b/R/xts.methods.R
@@ -262,7 +262,9 @@ window_idx <- function(x, index. = NULL, start = NULL, end = NULL)
     base_idx <- findInterval(index., idx)
     base_idx <- pmax(base_idx, 1)
     # Only include indexes where we have an exact match in the xts series
-    match <- idx[base_idx] == index.
+    ### match <- idx[base_idx] == index.
+    ### prevent NAs from creeping in
+    match <- sapply({idx[base_idx] == index.}, function(x) { if(is.na(x)) { FALSE } else { x } } )
     base_idx <- base_idx[match]
     index. <- index.[match]
     if(length(base_idx) < 1) return(x[NULL,])


### PR DESCRIPTION
Fix of 
Can't subset empty xts by date anymore #252
yields the desired result . . .
```r
> library(xts)
> testxts=xts(1,as.Date('2018-07-18'))
> str(testxts['2017'][as.Date('2018-07-17')])
An 'xts' object of zero-width
```

```r
> devtools::session_info()
Session info -------------------------------------------------------------------------------------------------------
 setting  value                       
 version  R version 3.5.1 (2018-07-02)
 system   x86_64, mingw32             
 ui       RStudio (1.1.453)           
 language (EN)                        
 collate  English_United States.1252  
 tz       America/Chicago             
 date     2018-07-23                  

Packages -----------------------------------------------------------------------------------------------------------
 package    * version date       source                          
 base       * 3.5.1   2018-07-02 local                           
 commonmark   1.5     2018-04-28 CRAN (R 3.5.1)                  
 compiler     3.5.1   2018-07-02 local                           
 datasets   * 3.5.1   2018-07-02 local                           
 devtools     1.13.6  2018-06-27 CRAN (R 3.5.1)                  
 digest       0.6.15  2018-01-28 CRAN (R 3.5.0)                  
 graphics   * 3.5.1   2018-07-02 local                           
 grDevices  * 3.5.1   2018-07-02 local                           
 grid         3.5.1   2018-07-02 local                           
 lattice      0.20-35 2017-03-25 CRAN (R 3.5.0)                  
 magrittr   * 1.5     2014-11-22 CRAN (R 3.5.0)                  
 memoise      1.1.0   2017-04-21 CRAN (R 3.5.0)                  
 methods    * 3.5.1   2018-07-02 local                           
 R6           2.2.2   2017-06-17 CRAN (R 3.5.0)                  
 Rcpp         0.12.18 2018-07-23 CRAN (R 3.5.1)                  
 roxygen2     6.0.1   2017-02-06 CRAN (R 3.5.1)                  
 rstudioapi   0.7     2017-09-07 CRAN (R 3.5.0)                  
 stats      * 3.5.1   2018-07-02 local                           
 stringi      1.2.4   2018-07-20 CRAN (R 3.5.1)                  
 stringr      1.3.1   2018-05-10 CRAN (R 3.5.0)                  
 tools        3.5.1   2018-07-02 local                           
 utils      * 3.5.1   2018-07-02 local                           
 withr        2.1.2   2018-04-27 Github (jimhester/withr@79d7b0d)
 xml2         1.2.0   2018-01-24 CRAN (R 3.5.0)                  
 xts        * 0.11-0  <NA>       local                           
 yaml         2.1.19  2018-05-01 CRAN (R 3.5.0)                  
 zoo        * 1.8-3   2018-07-16 CRAN (R 3.5.1)      
```