### PR TITLE
Fix illegal read in fill_window_dups_rev

### DIFF
--- a/src/binsearch.c
+++ b/src/binsearch.c
@@ -203,6 +203,9 @@ SEXP fill_window_dups_rev(SEXP _x, SEXP _index)
   /* truncate so length(_out) = k
    * NB: output is in reverse order!
    */
-  UNPROTECT(1);
-  return lengthgets(_out, k);
+
+  SEXP _trunc = PROTECT(lengthgets(_out, k));
+  UNPROTECT(2);
+  
+  return _trunc;
 }


### PR DESCRIPTION
I'm not 100% sure this is the appropriate fix but it seems to fix my example.

'Writing R Extensions' says:

> Protection is not needed for objects which R already knows are in use. In particular, this
applies to function arguments.

Which makes me think that the original code should be fine, but it also says:
>in general we do not know (nor want to know) what is hiding behind the
R macros and functions we use, and any of them might cause memory to be allocated, hence
garbage collection and hence our object ab to be removed. It is usually wise to err on the side
of caution and assume that any of the R macros and functions might remove the object.

Could `lengthgets` be triggering the garbage collection and deleting the unprotected `_out` even though it's a function argument?
