### PR TITLE
270 fix len logic2 (#1)

### DIFF
--- a/R/xts.R
+++ b/R/xts.R
@@ -76,7 +76,7 @@ function(x=NULL,
     x <- as.matrix(x)
   } else x <- numeric(0)
 
-  if(orderBy == "timeDate" && missing(tzone)) {
+  if(orderBy[1L] == "timeDate" && missing(tzone)) {
     tzone <- order.by@FinCenter
   } else
   if(!is.null(attr(order.by,"tzone")) && missing(tzone))


### PR DESCRIPTION
* Fix if class(order.by) > 1

When class(order.by) has a length other than one, it will reach this
line but only the first element will be used.  We should make this
explicit and indeed must in case the environment variable _R_CHECK_LENGTH_1_LOGIC2_ is set, whereupon this line will emit an error
or warning.