### PR TITLE
Add futher examples to  documentation on time of day subsetting.

### DIFF
--- a/man/subset.xts.Rd
+++ b/man/subset.xts.Rd
@@ -111,6 +111,7 @@ Jeffrey A. Ryan
 \seealso{
 \code{\link{xts}},
 \code{\link{.parseISO8601}},
+\code{\link{.index}}
 }
 \examples{
 x <- xts(1:3, Sys.Date()+1:3)
@@ -155,5 +156,41 @@ x['1999/200001'] # January 2000
 x['2000/200005'] # 2000-01 to 2000-05
 x['2000/2000-04-01'] # through April 01, 2000
 y['2000/2000-04-01'] # through April 01, 2000 (using POSIXct series)
+
+
+### Time of day subsetting 
+
+i <- 0:60000
+focal_date <- as.numeric(as.POSIXct("2018-02-01", tz = "UTC"))
+x <- .xts(i, c(focal_date + i * 15), tz = "UTC", dimnames = list(NULL, "value"))
+
+# Select all observations between 9am and 15:59:59.99999:
+w1 <- x["T09/T15"] # or x["T9/T15"]
+head(w1)
+
+# timestring is of the form THH:MM:SS.ss/THH:MM:SS.ss
+
+# Select all observations between 13:00:00 and 13:59:59.9999 in two ways:
+y1 <- x["T13/T13"]
+head(y1)
+
+x[.indexhour(x) == 13]
+
+# Select all observations between 9:30am and 30 seconds, and 4.10pm:
+x["T09:30:30/T16:10"]
+
+# It is possible to subset time of day overnight.
+# e.g. This is useful for subsetting FX time series which trade 24 hours on week days
+
+# Select all observations between 23:50 and 00:15 the following day, in the xts time zone
+z <- x["T23:50/T00:14"]
+z["2018-02-10 12:00/"] # check the last day
+
+
+# Select all observations between 7pm and 8.30am the following day:
+z2 <- x["T19:00/T08:29:59"]
+head(z2); tail(z2)
+
+
 }
 \keyword{ utilities }

--- a/man/tclass.Rd
+++ b/man/tclass.Rd
@@ -126,5 +126,56 @@ x[.indexhour(x) \%in\% c(8,15) & .indexmin(x) \%in\% c(0:5,57:59)]
 tformat(x) <- "\%Y-\%b-\%d \%H:\%M:\%OS3"
 head(x)
 
+i <- 0:60000
+focal_date <- as.numeric(as.POSIXct("2018-02-01", tz = "UTC"))
+x <- .xts(i, c(focal_date + i * 15), tz = "UTC", dimnames = list(NULL, "value"))
+
+#select all observations for the first minute of each hour:
+x[.indexmin(x) == 0]
+
+# Select all observations for Monday:
+mon <- x[.indexwday(x) == 1]
+head(mon) ; tail(mon)
+unique(weekdays(index(mon))) # check
+
+
+# Disjoint time of day selections
+
+# Select all observations between 08:30 and 08:59:59.9999  or between 12:00 and 12:14:59.99999:
+x[.indexhour(x) == 8 & .indexmin(x) >= 30 | .indexhour(x) == 12 & .indexmin(x) \%in\% 0:14]
+
+### Compound selections
+
+# Select all observations for Wednesdays or Fridays between 9am and 4pm (exclusive of 4pm):
+x[.indexwday(x) \%in\% c(3, 5) & (.indexhour(x) \%in\%  c(9:15))]
+
+# Select all observations on Monday between 8:59:45 and 09:04:30:
+
+x[.indexwday(x) == 1 & (.indexhour(x) == 8 & .indexmin(x) == 59 & .indexsec(x) >= 45 |
+                          .indexhour(x) == 9 & 
+                          (.indexmin(x) < 4 | .indexmin(x) == 4 & .indexsec(x) <= 30))]
+
+i <- 0:30000
+u <- .xts(i, c(focal_date + i * 1800), tz = "UTC", dimnames = list(NULL, "value"))
+
+# Select all observations for January or February:
+u[.indexmon(u) \%in\% c(0, 1) ]
+
+# Select all data for the 28th to 31st of each month, excluding any Fridays:
+u[.indexmday(u) \%in\% 28:31 & .indexwday(u) != 5]
+
+# Subset by week since origin
+
+unique(.indexweek(u))
+origin <- xts(1, as.POSIXct("1970-01-01"))
+unique(.indexweek(origin))
+
+# e.g. select all observations in weeks 2515 to 2517.
+u2 <- u[.indexweek(u) \%in\% 2515:2517]
+head(u2); tail(u2)
+
+# select all observations after 12pm for day 50 and 51 in each year
+u[.indexyday(u) \%in\% 50:51 & .indexhour(u) >= 12]
+
 }
 \keyword{ utilities }


### PR DESCRIPTION
Expand the examples in the documentation for subset.xts and tclass.

In subset.xts.Rd, extend \{seealso to include a reference to .index, as both help pages relate to subsetting.

In tclass.Rd, provide examples for each kind of subsetting available.

Fixes Issue #304

