### PR TITLE
Add ylab to plot.xts

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -131,7 +131,6 @@ plot.xts <- function(x,
                      lwd=2,
                      lend=1,
                      main=deparse(substitute(x)),
-                     ylab=NULL,
                      observation.based=FALSE,
                      ylim=NULL,
                      yaxis.same=TRUE,
@@ -558,10 +557,7 @@ plot.xts <- function(x,
     }
   }
   assign(".xts_chob", cs, .plotxtsEnv)
-  plot(cs)
-  if(hasArg(ylab)){
-    title(ylab = ylab)
-  }
+  cs
 }
 
 # apply a function to the xdata in the xts chob and add a panel with the result

--- a/R/plot.R
+++ b/R/plot.R
@@ -286,6 +286,7 @@ plot.xts <- function(x,
   cs$Env$column_names <- colnames(x)
   cs$Env$nobs <- NROW(cs$Env$xdata)
   cs$Env$main <- main
+  cs$Env$ylab <- if (hasArg("ylab")) eval.parent(plot.call$ylab) else ""
   
   # Set xlim using the raw returns data passed into function
   # xlim can be based on observations or time
@@ -411,6 +412,10 @@ plot.xts <- function(x,
                              col=theme$labels, srt=theme$srt, offset=1, pos=4,
                              cex=theme$cex.axis, xpd=TRUE)))
   }
+
+  # ylab
+  exp <- c(exp, expression(title(ylab = ylab[1], mgp = c(1, 1, 0))))
+
   cs$add(exp, env=cs$Env, expr=TRUE)
   
   # add main series

--- a/R/plot.R
+++ b/R/plot.R
@@ -131,6 +131,7 @@ plot.xts <- function(x,
                      lwd=2,
                      lend=1,
                      main=deparse(substitute(x)),
+                     ylab=NULL,
                      observation.based=FALSE,
                      ylim=NULL,
                      yaxis.same=TRUE,
@@ -557,7 +558,10 @@ plot.xts <- function(x,
     }
   }
   assign(".xts_chob", cs, .plotxtsEnv)
-  cs
+  plot(cs)
+  if(hasArg(ylab)){
+    title(ylab = ylab)
+  }
 }
 
 # apply a function to the xdata in the xts chob and add a panel with the result


### PR DESCRIPTION
Few things worth mentioning:

1. Tried to do this in chart.lines() but ylab was not passing through
2. Need a solution for when multi.panel is not NULL, perhaps a character vector of ylab strings?
3. Needed the plot printed before i could add title() hence cs becomes plot(cs)

Simple test is add ylab argument to plot.xts()

See #333

Please review the [contributing guide](CONTRIBUTING.md) before submitting your pull request. Please pay special attention to the [pull request](CONTRIBUTING.md#want-to-submit-a-pull-request) and [commit message](CONTRIBUTING.md#commit-messages) sections. Thanks for your contribution and interest in the project!
