### PR TITLE
Update API header and standardize two signatures (closes #317)

### DIFF
--- a/inst/include/xts.h
+++ b/inst/include/xts.h
@@ -77,7 +77,7 @@ SEXP make_index_unique(SEXP x, SEXP eps);
 SEXP make_unique(SEXP X, SEXP eps);
 SEXP endpoints(SEXP _x, SEXP _on, SEXP _k, SEXP _addlast);
 SEXP do_merge_xts(SEXP x, SEXP y, SEXP all, SEXP fill, SEXP retclass, SEXP colnames, 
-                  SEXP suffixes, SEXP retside, SEXP check_names, SEXP env, int coerce);
+                  SEXP suffixes, SEXP retside, SEXP check_names, SEXP env, SEXP coerce);
 SEXP na_omit_xts(SEXP x);
 SEXP na_locf(SEXP x, SEXP fromlast, SEXP maxgap, SEXP limit);
 

--- a/inst/include/xts.h
+++ b/inst/include/xts.h
@@ -95,7 +95,7 @@ void copyAttributes(SEXP x, SEXP y);    // internal only
 void copy_xtsAttributes(SEXP x, SEXP y);    // internal only
 void copy_xtsCoreAttributes(SEXP x, SEXP y);// internal only    
 
-int isXts(SEXP x);                          // is.xts analogue
+SEXP isXts(SEXP x);                         // is.xts analogue
 int firstNonNA(SEXP x);
 SEXP extract_col (SEXP x, SEXP j, SEXP drop, SEXP first_, SEXP last_);
 #endif /* _XTS */

--- a/inst/include/xtsAPI.h
+++ b/inst/include/xtsAPI.h
@@ -106,10 +106,10 @@ SEXP attribute_hidden xtsEndpoints(SEXP x, SEXP on, SEXP k, SEXP addlast) {
 
 SEXP attribute_hidden xtsMerge(SEXP x, SEXP y, SEXP all, SEXP fill, SEXP retclass, 
                                SEXP colnames, SEXP suffixes, SEXP retside, SEXP check_names,
-                               SEXP env, int coerce) {
-    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,int) = NULL;
+                               SEXP env, SEXP coerce) {
+    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP) = NULL;
     if (fun == NULL) 
-        fun = (SEXP(*)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,int)) R_GetCCallable("xts","do_merge_xts");
+        fun = (SEXP(*)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP)) R_GetCCallable("xts","do_merge_xts");
     return fun(x, y, all, fill, retclass, colnames, suffixes, retside, check_names, env, coerce);
 }
 

--- a/inst/include/xtsAPI.h
+++ b/inst/include/xtsAPI.h
@@ -105,11 +105,12 @@ SEXP attribute_hidden xtsEndpoints(SEXP x, SEXP on, SEXP k, SEXP addlast) {
 }
 
 SEXP attribute_hidden xtsMerge(SEXP x, SEXP y, SEXP all, SEXP fill, SEXP retclass, 
-                               SEXP colnames, SEXP suffixes, SEXP retside, SEXP env, int coerce) {
-    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,int) = NULL;
+                               SEXP colnames, SEXP suffixes, SEXP retside, SEXP check_names,
+                               SEXP env, int coerce) {
+    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,int) = NULL;
     if (fun == NULL) 
-        fun = (SEXP(*)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,int)) R_GetCCallable("xts","do_merge_xts");
-    return fun(x, y, all, fill, retclass, colnames, suffixes, retside, env, coerce);
+        fun = (SEXP(*)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,int)) R_GetCCallable("xts","do_merge_xts");
+    return fun(x, y, all, fill, retclass, colnames, suffixes, retside, check_names, env, coerce);
 }
 
 SEXP attribute_hidden xtsNaOmit(SEXP x) {

--- a/inst/include/xtsAPI.h
+++ b/inst/include/xtsAPI.h
@@ -41,10 +41,10 @@ extern "C" {
     fun = ( RETURNTYPE(*)(ARG1,ARG2)) R_GetCCallable("PACKAGENAME", "FUNCTIONNAME")
 
 */
-int attribute_hidden xtsIs(SEXP x)
+SEXP attribute_hidden xtsIs(SEXP x)
 {
-  static int(*fun)(SEXP) = NULL;
-  if (fun == NULL) fun = (int(*)(SEXP)) R_GetCCallable("xts","isXts");
+  static SEXP(*fun)(SEXP) = NULL;
+  if (fun == NULL) fun = (SEXP(*)(SEXP)) R_GetCCallable("xts","isXts");
   return fun(x);
 }
 

--- a/man/xtsAPI.Rd
+++ b/man/xtsAPI.Rd
@@ -22,7 +22,7 @@ Callable from other R packages:
   SEXP xtsLag(SEXP x, SEXP k, SEXP pad)
 
 Internal use functions:
-  int isXts(SEXP x)
+  SEXP isXts(SEXP x)
   void copy_xtsAttributes(SEXP x, SEXP y)
   void copy_xtsCoreAttributes(SEXP x, SEXP y)
 

--- a/src/isXts.c
+++ b/src/isXts.c
@@ -25,7 +25,7 @@
 #include <Rdefines.h>
 #include "xts.h"
 
-int isXts(SEXP x) 
+SEXP isXts(SEXP x)
 {
   int i;
   SEXP attr, index;
@@ -34,7 +34,7 @@ int isXts(SEXP x)
   PROTECT( attr = coerceVector(getAttrib(x, R_ClassSymbol),STRSXP) );
   if(length(attr) <= 1) {
     UNPROTECT(1);
-    return 0;
+    return Rf_ScalarInteger(0);
   }
 
   for(i = 0; i < length(attr); i++) {
@@ -42,22 +42,22 @@ int isXts(SEXP x)
       /* check for index attribute */
       if(TYPEOF(index)==REALSXP || TYPEOF(index)==INTSXP) {
         UNPROTECT(1);
-        return 1;
+        return Rf_ScalarInteger(1);
       } else {
         UNPROTECT(1);
-        return 0;
+        return Rf_ScalarInteger(0);
       }
     }
   }
   UNPROTECT(1);
-  return FALSE;
+  return Rf_ScalarInteger(FALSE);
 
 }
 
 /* test function and example */
 SEXP test_isXts(SEXP x)
 {
-  if(isXts(x)) {
+    if(Rf_asInteger(isXts(x))) {
     Rprintf("TRUE\n");
   } else {
     Rprintf("FALSE\n");

--- a/src/merge.c
+++ b/src/merge.c
@@ -67,7 +67,7 @@ SEXP do_merge_xts (SEXP x, SEXP y,
                    SEXP retside,
                    SEXP check_names,
                    SEXP env,
-                   int coerce)
+                   SEXP coerce)
 {
   int nrx, ncx, nry, ncy, len;
   int left_join, right_join;
@@ -269,7 +269,7 @@ SEXP do_merge_xts (SEXP x, SEXP y,
      either here or in the calling R code.  I suspect here is
      more useful if other function can call the C code as well. 
      If objects are not the same type, convert to REALSXP. */
-  if( coerce || TYPEOF(x) != TYPEOF(y) ) {
+  if( Rf_asInteger(coerce) || TYPEOF(x) != TYPEOF(y) ) {
     PROTECT( x = coerceVector(x, REALSXP) ); p++;
     PROTECT( y = coerceVector(y, REALSXP) ); p++;
   }
@@ -1116,7 +1116,7 @@ SEXP mergeXts (SEXP args) // mergeXts {{{
                                              rets,
                                              check_names,
                                              env,
-                                             coerce_to_double), &idx); P++;
+                                             Rf_ScalarInteger(coerce_to_double)), &idx); P++;
 
     /* merge all objects into one zero-width common index */
     while(args != R_NilValue) { 
@@ -1131,7 +1131,7 @@ SEXP mergeXts (SEXP args) // mergeXts {{{
                                         rets,
                                         check_names,
                                         env,
-                                        coerce_to_double), idx);
+                                        Rf_ScalarInteger(coerce_to_double)), idx);
       }
       args = CDR(args);
     }
@@ -1169,7 +1169,7 @@ SEXP mergeXts (SEXP args) // mergeXts {{{
                                     retside,
                                     check_names,
                                     env,
-                                    coerce_to_double), idxtmp);
+                                    Rf_ScalarInteger(coerce_to_double)), idxtmp);
 
       nr = nrows(xtmp);
       nc = (0 == nr) ? 0 : ncols(xtmp);  // ncols(numeric(0)) == 1
@@ -1297,7 +1297,7 @@ SEXP mergeXts (SEXP args) // mergeXts {{{
                              retside,
                          check_names,
                                  env,
-                    coerce_to_double)); P++;
+   Rf_ScalarInteger(coerce_to_double))); P++;
   }
 
   SEXP index_tmp = getAttrib(result, xts_IndexSymbol);

--- a/src/merge.c
+++ b/src/merge.c
@@ -102,7 +102,7 @@ SEXP do_merge_xts (SEXP x, SEXP y,
   PROTECT( xindex = getAttrib(x, xts_IndexSymbol) ); p++;
 
   /* convert to xts object if needed */
-  if( !isXts(y) ) {
+  if( !Rf_asInteger(isXts(y)) ) {
     PROTECT(s = t = allocList(4)); p++;
     SET_TYPEOF(s, LANGSXP);
     SETCAR(t, install("try.xts")); t = CDR(t);
@@ -118,7 +118,7 @@ SEXP do_merge_xts (SEXP x, SEXP y,
 
   mode = TYPEOF(x);
 
-  if( isXts(y) ) {
+  if( Rf_asInteger(isXts(y)) ) {
     PROTECT( yindex = getAttrib(y, xts_IndexSymbol) ); p++;
   } else {
     PROTECT( yindex = getAttrib(x, xts_IndexSymbol) ); p++;
@@ -1068,7 +1068,7 @@ SEXP mergeXts (SEXP args) // mergeXts {{{
   args = CDR(args);
 
   int leading_non_xts = 0;
-  while( !isXts(_x) ) {
+  while( !Rf_asInteger(isXts(_x)) ) {
     if( args == R_NilValue ) error("no xts object to merge");
     leading_non_xts = 1;
     /*warning("leading non-xts objects may have been dropped");*/

--- a/src/na.c
+++ b/src/na.c
@@ -392,7 +392,7 @@ SEXP na_locf (SEXP x, SEXP fromLast, SEXP _maxgap, SEXP _limit)
       error("unsupported type");
       break;
   }
-  if(isXts(x)) {
+  if(Rf_asInteger(isXts(x))) {
     setAttrib(result, R_DimSymbol, getAttrib(x, R_DimSymbol));
     setAttrib(result, R_DimNamesSymbol, getAttrib(x, R_DimNamesSymbol));
     setAttrib(result, xts_IndexSymbol, getAttrib(x, xts_IndexSymbol));

--- a/src/rbind.c
+++ b/src/rbind.c
@@ -57,10 +57,10 @@ SEXP do_rbind_xts (SEXP x, SEXP y, SEXP dup)
     return y;
   }
 
-  if( !isXts(x) ) {
+  if( !Rf_asInteger(isXts(x)) ) {
     PROTECT( x = tryXts(x) ); P++;
   }
-  if( !isXts(y) ) {
+  if( !Rf_asInteger(isXts(y)) ) {
     PROTECT( y = tryXts(y) ); P++;
   }
 

--- a/src/tryXts.c
+++ b/src/tryXts.c
@@ -26,14 +26,14 @@
 
 SEXP tryXts (SEXP x)
 {
-  if( !isXts(x) ) {
+  if( !Rf_asInteger(isXts(x)) ) {
     SEXP s, t, result;
     PROTECT(s = t = allocList(2));
     SET_TYPEOF(s, LANGSXP);
     SETCAR(t, install("try.xts")); t = CDR(t);
     SETCAR(t, x); t=CDR(t);
     PROTECT(result = eval(s, R_GlobalEnv));
-    if( !isXts(result) ) {
+    if( !Rf_asInteger(isXts(result)) ) {
       UNPROTECT(2);
       error("rbind.xts requires xtsible data");
     }


### PR DESCRIPTION
This pull request start as a very narrow fix for the obvious bug of xtsAPI.h not having caught up with the expanded signature of xtsMerge -- the more recently added parameter was not reflected.  That is the first commit, and I would be entirely open to cherry picking it out and making this a separate PR.

The remainder addresses the longer overdue issue #317 and corrects two signatures called by `.Call` to be all `SEXP` as required by the R API contract.  The changes may look invasive but they really are as the fix "merely" consists of replacing (scalar) use of an `int` on the way in and out, respectively, for `do_merge_xts` and `is_xts` -- so it really only consisted of adding the appropriate R API wrapper for to/from integer conversion.

Feel free to merge or ignore or squash or whatever.  It would be terrific the exposed `xtsAPI.h` header could make its way to CRAN.  As it is currently stands I cannot call `xtsMerge` from the `RcppXts` package due to the mismatch.