### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - name: "Linux tests"
       os: linux
-      dist: trusty
+      dist: bionic
       sudo: required
 
     - name: "macOS tests"
@@ -14,16 +14,16 @@ matrix:
 
     - name: "Linux tests conditional Suggests"
       os: linux
-      dist: trusty
+      dist: bionic
       sudo: required
       env: _R_CHECK_DEPENDS_ONLY_=true
 
+env:
+  global:
+    - R_VERSION="4.0"
+      
 before_install:
   - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  # add our launchpad repo which has (inter alia) the newest QuantLib
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      sudo add-apt-repository -y ppa:edd/misc;
-    fi
   - ./run.sh bootstrap
 
 install:


### PR DESCRIPTION
This PR does three things
- switch to bionic aka 18.04 which is less behind the times than
  trusty (14.04) or xenial (16.04) which are also available
  this can be reverted
- remove the addition of the (outdated, I think) 'edd/misc' PPA; should you need
  or want packages I have two other ones but the (new, used from r-travis.sh)
  Rutter PPA should have you covered
- sets the R_VERSION variable to R 4.0.  You can also opt into 3.5 which I do
  in one or two repos to have a matrix; I am mostly content with 4.0 only

If you were to merge this I can easily rebase #337 off it, or vice versa.  This one is of course simpler.
