### PR TITLE
Simplify API header to just assignment in static skipping null comparison

### DIFF
--- a/inst/include/xtsAPI.h
+++ b/inst/include/xtsAPI.h
@@ -41,87 +41,74 @@ extern "C" {
     fun = ( RETURNTYPE(*)(ARG1,ARG2)) R_GetCCallable("PACKAGENAME", "FUNCTIONNAME")
 
 */
-SEXP attribute_hidden xtsIs(SEXP x)
-{
-  static SEXP(*fun)(SEXP) = NULL;
-  if (fun == NULL) fun = (SEXP(*)(SEXP)) R_GetCCallable("xts","isXts");
+SEXP attribute_hidden xtsIs(SEXP x) {
+  static SEXP(*fun)(SEXP) = (SEXP(*)(SEXP)) R_GetCCallable("xts","isXts");
   return fun(x);
 }
 
-SEXP attribute_hidden xtsIsOrdered(SEXP x, SEXP increasing, SEXP strictly)
-{
-  static SEXP(*fun)(SEXP,SEXP,SEXP) = NULL;
-  if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("xts","do_is_ordered");
+SEXP attribute_hidden xtsIsOrdered(SEXP x, SEXP increasing, SEXP strictly) {
+  static SEXP(*fun)(SEXP,SEXP,SEXP) = (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("xts","do_is_ordered");
   return fun(x, increasing, strictly);
 }
 
-SEXP attribute_hidden xtsNaCheck(SEXP x, SEXP check)
-{
-  static SEXP(*fun)(SEXP,SEXP) = NULL;
-  if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP)) R_GetCCallable("xts","naCheck");
+SEXP attribute_hidden xtsNaCheck(SEXP x, SEXP check) {
+  static SEXP(*fun)(SEXP,SEXP) = (SEXP(*)(SEXP,SEXP)) R_GetCCallable("xts","naCheck");
   return fun(x, check);
 }
 
 SEXP attribute_hidden xtsTry(SEXP x) {
-    static SEXP(*fun)(SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP)) R_GetCCallable("xts","tryXts");
+    static SEXP(*fun)(SEXP) = (SEXP(*)(SEXP)) R_GetCCallable("xts","tryXts");
     return fun(x);
 }
     
 SEXP attribute_hidden xtsRbind(SEXP x, SEXP y, SEXP dup) {
-    static SEXP(*fun)(SEXP, SEXP, SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("xts","do_rbind_xts");
+    static SEXP(*fun)(SEXP, SEXP, SEXP) =
+      (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("xts","do_rbind_xts");
     return fun(x, y, dup);
 }
 
 SEXP attribute_hidden xtsCoredata(SEXP x) {
-    static SEXP(*fun)(SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP)) R_GetCCallable("xts","coredata_xts");
+    static SEXP(*fun)(SEXP) = (SEXP(*)(SEXP)) R_GetCCallable("xts","coredata_xts");
     return fun(x);
 }
 
 SEXP attribute_hidden xtsLag(SEXP x, SEXP k, SEXP pad) {
-    static SEXP(*fun)(SEXP,SEXP,SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("xts","lagXts");
+    static SEXP(*fun)(SEXP,SEXP,SEXP) = (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("xts","lagXts");
     return fun(x, k, pad);
 }
 
 SEXP attribute_hidden xtsMakeIndexUnique(SEXP x, SEXP eps) {
-    static SEXP(*fun)(SEXP,SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP)) R_GetCCallable("xts","make_index_unique");
+    static SEXP(*fun)(SEXP,SEXP) = (SEXP(*)(SEXP,SEXP)) R_GetCCallable("xts","make_index_unique");
     return fun(x, eps);
 }
 
 SEXP attribute_hidden xtsMakeUnique(SEXP x, SEXP eps) {
-    static SEXP(*fun)(SEXP,SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP)) R_GetCCallable("xts","make_unique");
+    static SEXP(*fun)(SEXP,SEXP) = (SEXP(*)(SEXP,SEXP)) R_GetCCallable("xts","make_unique");
     return fun(x, eps);
 }
 
 SEXP attribute_hidden xtsEndpoints(SEXP x, SEXP on, SEXP k, SEXP addlast) {
-    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP,SEXP,SEXP)) R_GetCCallable("xts","endpoints");
+    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP) =
+      (SEXP(*)(SEXP,SEXP,SEXP,SEXP)) R_GetCCallable("xts","endpoints");
     return fun(x, on, k, addlast);
 }
 
 SEXP attribute_hidden xtsMerge(SEXP x, SEXP y, SEXP all, SEXP fill, SEXP retclass, 
                                SEXP colnames, SEXP suffixes, SEXP retside, SEXP check_names,
                                SEXP env, SEXP coerce) {
-    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP) = NULL;
-    if (fun == NULL) 
-        fun = (SEXP(*)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP)) R_GetCCallable("xts","do_merge_xts");
+    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP) =
+      (SEXP(*)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP)) R_GetCCallable("xts","do_merge_xts");
     return fun(x, y, all, fill, retclass, colnames, suffixes, retside, check_names, env, coerce);
 }
 
 SEXP attribute_hidden xtsNaOmit(SEXP x) {
-    static SEXP(*fun)(SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP)) R_GetCCallable("xts","na_omit_xts");
+    static SEXP(*fun)(SEXP) = (SEXP(*)(SEXP)) R_GetCCallable("xts","na_omit_xts");
     return fun(x);
 }
 
 SEXP attribute_hidden xtsNaLocf(SEXP x, SEXP fromLast, SEXP maxgap, SEXP limit) {
-    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP) = NULL;
-    if (fun == NULL) fun = (SEXP(*)(SEXP,SEXP,SEXP,SEXP)) R_GetCCallable("xts","na_locf");
+    static SEXP(*fun)(SEXP,SEXP,SEXP,SEXP) =
+      (SEXP(*)(SEXP,SEXP,SEXP,SEXP)) R_GetCCallable("xts","na_locf");
     return fun(x, fromLast, maxgap, limit);
 }
 


### PR DESCRIPTION
As discussed, this simplifies the exported functions to the now-more-common two-line form. 
