### PR TITLE
Remove integer returning code for zero length POSIXct.

### DIFF
--- a/R/index.R
+++ b/R/index.R
@@ -38,8 +38,6 @@ function(x, ...) {
 
   #x.index  <- structure(.index(x), class=c("POSIXct","POSIXt"))
   x.index  <- .POSIXct(.index(x), tz=attr(.index(x), "tzone"))
-  if(length(x.index) == 0)
-    return(integer())
 
   if(!is.list(value)) 
     value <- as.list(value)


### PR DESCRIPTION
This is more consistent in terms of data typing.
Fixes #363.

Tried to follow PR guidelines, hopefully I didn't overlook something.
Did not attempt to include new tests since I'm only used to `testthat`.
Please give some guidelines on how/where to include them if deemed needed.