### PR TITLE
In window.xts, start and end values of NA will be treated the same as NULL

### DIFF
--- a/R/xts.methods.R
+++ b/R/xts.methods.R
@@ -396,6 +396,10 @@ window_idx <- function(x, index. = NULL, start = NULL, end = NULL)
 # that is, index. must be time based,
 window.xts <- function(x, index. = NULL, start = NULL, end = NULL, ...)
 {
+  # scalar NA values are treated as NULL
+  if (isTRUE(is.na(start))) start <- NULL
+  if (isTRUE(is.na(end))) end <- NULL
+  
   if(is.null(start) && is.null(end) && is.null(index.)) return(x)
 
   # dispatch to window.zoo() for yearmon and yearqtr

--- a/inst/tinytest/test-subset.R
+++ b/inst/tinytest/test-subset.R
@@ -278,6 +278,9 @@ w2 <- window(x2, start = "2015Q1")      # to window.zoo()
 expect_equal(r1, w1, info = paste(info_msg, "window, yearmon, character start"))
 expect_equal(r2, w2, info = paste(info_msg, "window, yearqtr, character start"))
 
+w1 <- window(x1, start = "2015-01-01", end = NA)  # to window.xts()
+expect_equal(r1, w1, info = paste(info_msg, "window, yearmon, character start with end = NA"))
+
 info_msg <- "test.zero_width_subset_does_not_drop_class"
 target <- c("custom", "xts", "zoo")
 x <- .xts(1:10, 1:10, class = target)

--- a/inst/tinytest/test-xts.methods.R
+++ b/inst/tinytest/test-xts.methods.R
@@ -152,6 +152,41 @@ bin <- window(x)
 reg <- window_dbg(x, start = start, end = end)
 expect_identical(bin, reg, info = paste(info_msg, "- end = NULL, start = NULL"))
 
+# Test just start, end = NA
+start <- base + 13 * DAY
+end <- base + 30*DAY
+bin <- window(x, start = start, end = NA)
+reg <- window_dbg(x, start = start, end = end)
+expect_identical(bin, reg, info = paste(info_msg, "- just start, end = NA"))
+
+# Test just start, end = NA, empty range
+start <- base + 25 * DAY
+end <- base + 30*DAY
+bin <- window(x, start = start, end = NA)
+reg <- window_dbg(x, start = start, end = end)
+expect_identical(bin, reg, info = paste(info_msg, "- just start, end = NA, empty range"))
+
+# Test just end, start = NA
+end <- base + 13 * DAY
+start <- base
+bin <- window(x, start = NA, end = end)
+reg <- window_dbg(x, start = start, end = end)
+expect_identical(bin, reg, info = paste(info_msg, "- just end, start = NA"))
+
+# Test just end, start = NA, empty range
+end <- base
+start <- base
+bin <- window(x, start = NA, end = end)
+reg <- window_dbg(x, start = start, end = end)
+expect_identical(bin, reg, info = paste(info_msg, "- just end, start = NA, empty range"))
+
+# Test end = NA, start = NA
+start <- base
+end <- base + 30*DAY
+bin <- window(x, start = NA, end = NA)
+reg <- window_dbg(x, start = start, end = end)
+expect_identical(bin, reg, info = paste(info_msg, "- end = NA, start = NA"))
+
 #######################################
 # Test for index. parameter
 start <- base


### PR DESCRIPTION
This is the pull request to support start/end arguments as NA.  

#345 

I was not sure what you meant by testing window.zoo as well.