### PR TITLE
Avoid double-loop and branching for leap years

### DIFF
--- a/src/startofyear.c
+++ b/src/startofyear.c
@@ -36,27 +36,22 @@ SEXP do_startofyear (SEXP _from, SEXP _to, SEXP _origin)
   int *fromto = INTEGER(_fromto);
 
   int nyear[1] = { (to - from + 1) };
-  int leap[nyear[0]];
-
 
   // generate sequence of dates to work with
   fromto[0] = from;
   for(i=1; i < nyear[0]; i++) {
     fromto[i] = fromto[i-1] + 1;
-  } 
-
-  for(i = 0; i < nyear[0]; i++) {
-    leap[ i ] = ( (fromto[ i ] % 4 == 0 && fromto[ i ] % 100 != 0)
-                 ||
-                   fromto[ i ] % 400 == 0) ? 1 : 0;
   }
 
+  int leap;
   for(i=0; i < nyear[0]; i++) {
-    if(leap[i] == 1) { // a leapyear (366 days)
-      fromto[i] = 366;
-    } else {           // a non-leapyear (365 days)
-      fromto[i] = 365;
-    }
+    // A leap year is every year divisible by 4 _except_
+    //   years also divisible by 100. Leap centuries,
+    //   those divisible by 400, also get 366 days.
+    leap = ( (fromto[ i ] % 4 == 0 && fromto[ i ] % 100 != 0)
+             ||
+             fromto[ i ] % 400 == 0) ? 1 : 0;
+    fromto[i] = 365 + leap;
   }
   
   /*

--- a/src/startofyear.c
+++ b/src/startofyear.c
@@ -43,14 +43,13 @@ SEXP do_startofyear (SEXP _from, SEXP _to, SEXP _origin)
     fromto[i] = fromto[i-1] + 1;
   }
 
-  int leap;
   for(i=0; i < nyear[0]; i++) {
     // A leap year is every year divisible by 4 _except_
     //   years also divisible by 100. Leap centuries,
     //   those divisible by 400, also get 366 days.
-    leap = ( (fromto[ i ] % 4 == 0 && fromto[ i ] % 100 != 0)
-             ||
-             fromto[ i ] % 400 == 0) ? 1 : 0;
+    int leap = ( (fromto[ i ] % 4 == 0 && fromto[ i ] % 100 != 0)
+                 ||
+                 fromto[ i ] % 400 == 0) ? 1 : 0;
     fromto[i] = 365 + leap;
   }
   

--- a/src/startofyear.c
+++ b/src/startofyear.c
@@ -48,8 +48,8 @@ SEXP do_startofyear (SEXP _from, SEXP _to, SEXP _origin)
     //   years also divisible by 100. Leap centuries,
     //   those divisible by 400, also get 366 days.
     int leap = ( (fromto[ i ] % 4 == 0 && fromto[ i ] % 100 != 0)
-                 ||
-                 fromto[ i ] % 400 == 0) ? 1 : 0;
+                ||
+                  fromto[ i ] % 400 == 0) ? 1 : 0;
     fromto[i] = 365 + leap;
   }
   


### PR DESCRIPTION
Supersedes #429.

Actually, we can avoid the variable-length array issue altogether. The old implementation uses `leap` to:

 1. Run a full `nyear` loop to populate whether each year is leap
 2. Run a second loop to read from this array to count the number of days. It also has a branch in each iteration which will be pretty volatile since branch prediction will be wrong ~half the time.

It's better to just count the number of days directly in a single loop. This will be slightly more memory-efficient, and should be more computationally efficient too.