### PR TITLE
Fix period.apply for multi-row functional returns

### DIFF
--- a/R/period.apply.R
+++ b/R/period.apply.R
@@ -121,15 +121,24 @@ function(x, INDEX, FUN, ...)
       INDEX <- c(INDEX, NROW(x))
     }
 
-    xx <- sapply(1:(length(INDEX) - 1), function(y) {
+    xx <- lapply(1:(length(INDEX) - 1), function(y) {
                    FUN(x[(INDEX[y] + 1):INDEX[y + 1]], ...)
                 })
-    if(is.vector(xx))
-      xx <- t(xx)
-    xx <- t(xx)
-    if(is.null(colnames(xx)) && NCOL(x)==NCOL(xx))
-      colnames(xx) <- colnames(x)
-    reclass(xx, x[INDEX])
+    
+    # If FUN returns an xts object, do.call(rbind) will use rbind.xts and preserve index.
+    # If FUN returns a vector/matrix, do.call(rbind) returns a matrix.
+    xx <- do.call(rbind, xx)
+    
+    # If xx is an xts object, we shouldn't reclass it to the endpoints.
+    # Joshua said: "We'll always rbind() the rollapply() output if it's an xts object...
+    # period.apply() should always rbind() the result when FUN returns a 1-row matrix. 
+    # The index should be set to the last index value in the period."
+    if (!is.xts(xx)) {
+      if(is.null(colnames(xx)) && NCOL(x)==NCOL(xx))
+        colnames(xx) <- colnames(x)
+      xx <- reclass(xx, x[INDEX])
+    }
+    xx
 }
 
 #' @rdname apply.monthly

--- a/R/period.apply.R
+++ b/R/period.apply.R
@@ -130,9 +130,8 @@ function(x, INDEX, FUN, ...)
     xx <- do.call(rbind, xx)
     
     # If xx is an xts object, we shouldn't reclass it to the endpoints.
-    # Joshua said: "We'll always rbind() the rollapply() output if it's an xts object...
     # period.apply() should always rbind() the result when FUN returns a 1-row matrix. 
-    # The index should be set to the last index value in the period."
+    # The index should be set to the last index value in the period.
     if (!is.xts(xx)) {
       if(is.null(colnames(xx)) && NCOL(x)==NCOL(xx))
         colnames(xx) <- colnames(x)

--- a/inst/tinytest/test-period.apply.R
+++ b/inst/tinytest/test-period.apply.R
@@ -125,3 +125,11 @@ expect_message(apply.daily(x, mean), pattern = "apply\\.daily\\(..., FUN = mean\
 expect_message(apply.monthly(x, mean), pattern = "apply\\.monthly\\(..., FUN = mean\\)")
 expect_message(apply.quarterly(x, mean), pattern = "apply\\.quarterly\\(..., FUN = mean\\)")
 expect_message(apply.yearly(x, mean), pattern = "apply\\.yearly\\(..., FUN = mean\\)")
+
+# test for multi-row output from FUN (Issue #382)
+info_msg <- "test.period.apply_multirow_output"
+x <- .xts(1:10, 1:10)
+ep <- c(0, 5, 10)
+res <- period.apply(x, ep, function(y) head(y, 2))
+expect_equal(NROW(res), 4, info = info_msg)
+expect_equal(as.numeric(res), c(1, 2, 6, 7), info = info_msg)


### PR DESCRIPTION
Fixes #382

### Description
This PR addresses the issue where `period.apply()` returns an unusual structure (a wide matrix) instead of preserving the chronological rows and dimensions when the applied function (`FUN`) returns more than one row per period (e.g., `cumsum` or `cummax`).

### Reproducible Example
```r
library(xts)
x <- .xts(1:10, 1:10)
ep <- c(0, 5, 10)

# Without this patch, this returns a flattened wide matrix instead of a 4-row xts object
period.apply(x, INDEX = ep, FUN = function(y) head(y, 2))
